### PR TITLE
Add support for detached heads, preventing fatal error.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/options-resolver": ">=2.3"
     },
     "require-dev": {
-        "symfony/filesystem": ">=2.3"
+        "symfony/filesystem": "~2.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,5 @@
         "psr-0": {
             "": "src"
         }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0.x-dev"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/process":"~2.0",
-        "symfony/options-resolver": ">=2.3"
+        "symfony/options-resolver": "~2.0"
     },
     "require-dev": {
-        "symfony/filesystem": ">=2.3"
+        "symfony/filesystem": "~2.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/process":">=2.3",
+        "symfony/process":"~2.0",
         "symfony/options-resolver": ">=2.3"
     },
     "require-dev": {
-        "symfony/filesystem": "~2.0"
+        "symfony/filesystem": ">=2.3"
     },
     "autoload": {
         "psr-0": {

--- a/src/PHPGit/Command/BranchCommand.php
+++ b/src/PHPGit/Command/BranchCommand.php
@@ -64,7 +64,10 @@ class BranchCommand extends Command
 
         foreach ($lines as $line) {
             $branch = array();
-            preg_match('/(?<current>\*| ) (?<name>[^\s]+) +((?:->) (?<alias>[^\s]+)|(?<hash>[0-9a-z]{7}) (?<title>.*))/', $line, $matches);
+            preg_match('/(?<current>\*| ) (?<name>[^\s]+)?(?<nobranch>\([\s\w]+\))? +((?:->) (?<alias>[^\s]+)|(?<hash>[0-9a-z]{7}) (?<title>.*))/', $line, $matches);
+            if (key_exists('nobranch', $matches) && $matches['nobranch']) {
+                $matches['name'] = $matches['nobranch'];
+            }
 
             $branch['current'] = ($matches['current'] == '*');
             $branch['name']    = $matches['name'];
@@ -226,4 +229,4 @@ class BranchCommand extends Command
             ->add('branch');
     }
 
-} 
+}

--- a/src/PHPGit/Git.php
+++ b/src/PHPGit/Git.php
@@ -262,7 +262,7 @@ class Git
 
     /**
      * Gets the Git repository path
-     * 
+     *
      * @return string
      */
     public function getRepository()

--- a/src/PHPGit/Git.php
+++ b/src/PHPGit/Git.php
@@ -261,6 +261,16 @@ class Git
     }
 
     /**
+     * Gets the Git repository path
+     * 
+     * @return string
+     */
+    public function getRepository()
+    {
+        return $this->directory;
+    }
+
+    /**
      * Returns version number
      *
      * @return mixed


### PR DESCRIPTION
Previously, if a repo was in detached head mode (git checkout <hash>), the branch parser would trigger a fatal error when trying to access the 'current' key. I adjusted the regex slightly to account for the "(no branch)" output and now the code parses successfully.
