### PR TITLE
Split in LogCommand accomodates empty arguments

### DIFF
--- a/src/PHPGit/Command/LogCommand.php
+++ b/src/PHPGit/Command/LogCommand.php
@@ -75,7 +75,7 @@ class LogCommand extends Command
         $lines  = $this->split($output);
 
         foreach ($lines as $line) {
-            list($hash, $name, $email, $date, $title) = preg_split('/\|\|/', $line, -1, PREG_SPLIT_NO_EMPTY);
+            list($hash, $name, $email, $date, $title) = preg_split('/\|\|/', $line, -1);
             $commits[] = array(
                 'hash'  => $hash,
                 'name'  => $name,


### PR DESCRIPTION
When an entry doesn't contain something optional (like an e-mail address), it would give a notice and the variables would not contain the correct content.
