### PR TITLE
Updating Archive Command to allow for the --remote option

### DIFF
--- a/src/PHPGit/Command/ArchiveCommand.php
+++ b/src/PHPGit/Command/ArchiveCommand.php
@@ -50,6 +50,10 @@ class ArchiveCommand extends Command
             $builder->add('--prefix=' . $options['prefix']);
         }
 
+        if ($options['remote']) {
+            $builder->add('--remote=' . $options['remote']);
+        }
+
         $builder->add('-o')->add($file);
 
         if ($tree) {
@@ -79,12 +83,14 @@ class ArchiveCommand extends Command
     {
         $resolver->setDefaults(array(
             'format' => null,
-            'prefix' => null
+            'prefix' => null,
+            'remote' => null
         ));
 
         $resolver->setAllowedTypes(array(
             'format' => array('null', 'string'),
-            'prefix' => array('null', 'string')
+            'prefix' => array('null', 'string'),
+            'remote' => array('null', 'string')
         ));
 
         $resolver->setAllowedValues(array(

--- a/test/PHPGit/Command/ArchiveCommandTest.php
+++ b/test/PHPGit/Command/ArchiveCommandTest.php
@@ -29,4 +29,17 @@ class ArchiveCommandTest extends BaseTestCase
         $this->assertFileExists($this->directory . '/test.zip');
     }
 
+    public function testRemoteArchive()
+    {
+        $git = new Git();
+        $git->init($this->directory);
+
+        # We expect to get github.com to throw an exception since it doesn't allow remote archives
+        $this->setExpectedException('PHPGit\Exception\GitException', "Invalid command: 'git-upload-archive '");
+        $git->archive($this->directory . '/test_test.zip', 'master', null, array(
+            'format' => 'zip',
+            'remote' => 'ssh://git@github.com/kzykhys/PHPGit.git'
+        ));
+    }
+
 } 


### PR DESCRIPTION
for #9
Adding the ability to have a remote option in the Archive command. Added a unit test; however, it's not very good.
