### PR TITLE
Added timeout support

### DIFF
--- a/src/PHPGit/Git.php
+++ b/src/PHPGit/Git.php
@@ -181,10 +181,13 @@ class Git
     /** @var string  */
     private $directory = '.';
 
+    /** @var integer  */
+    private $timeout = 60;
+
     /**
      * Initializes sub-commands
      */
-    public function __construct()
+    public function __construct($timeout = 60)
     {
         $this->add      = new Command\AddCommand($this);
         $this->archive  = new Command\ArchiveCommand($this);
@@ -212,6 +215,8 @@ class Git
         $this->status   = new Command\StatusCommand($this);
         $this->tag      = new Command\TagCommand($this);
         $this->tree     = new Command\TreeCommand($this);
+        
+        $this->timeout = $timeout;
     }
 
     /**
@@ -283,7 +288,8 @@ class Git
     {
         return ProcessBuilder::create()
             ->setPrefix($this->bin)
-            ->setWorkingDirectory($this->directory);
+            ->setWorkingDirectory($this->directory)
+            ->setTimeout($this->timeout);
     }
 
     /**


### PR DESCRIPTION
The Git class constructor now allows to define a non-standard (60 seconds) timeout for the processes it launches, since many times it is normal that such executions take much more time, specially when cloning or pushing to a new repository.

I'm handling big repositories that take a long time to clone and I wasn't being able to clone them (and other operations) through the library, because by default all processes of the Symfony Process Component have a timeout of 60 seconds. I've added an optional parameter on the constructor to change the global timeout to be used in each process launched to make possible to set an higher value.
