### PR TITLE
UPDATED: Got the branch command compatible with GIT versions lower than 1.7.7

### DIFF
--- a/src/PHPGit/Command/BranchCommand.php
+++ b/src/PHPGit/Command/BranchCommand.php
@@ -50,11 +50,11 @@ class BranchCommand extends Command
             ->add('-v')->add('--abbrev=7');
 
         if ($options['remotes']) {
-            $builder->add('--remotes');
+            $builder->add('-r');
         }
 
         if ($options['all']) {
-            $builder->add('--all');
+            $builder->add('-a');
         }
 
         $process = $builder->getProcess();


### PR DESCRIPTION
Converted the branch command --remotes and --all options to their short form (-a and -r) to allow compatibility for versions of git lower than 1.7.7
